### PR TITLE
Update plugin hashes to include setuptools-scm fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ plugins = [
  "nomad-ikz-fz @ git+https://github.com/IKZ-Berlin/ikz-fz-nomad-plugin.git@3a8dbfb8b5bc2c6ef53d997cc2097cf70f17c27b",
  "nomad_ikz_raman @ git+https://github.com/IKZ-Berlin/IKZ_raman.git@797a36fa985412e00527d4298f763eb2318a3ec4",
  "nomad_ikz_omega_theta_xrd @ git+https://github.com/IKZ-Berlin/ikz-omega-theta-xrd.git@e7049b305f6f5387008f8350f4a9f01bd942c386", 
- "rtg-sims @ git+https://github.com/FAIRmat-NFDI/AreaA-data_modeling_and_schemas.git@c286f23d14dcb2e4dc32454f9ee1a2c467428c77#subdirectory=rtg-sims", 
+ "rtg-sims @ git+https://github.com/FAIRmat-NFDI/AreaA-data_modeling_and_schemas.git@d7db1bc694342aaf8d628da2febca237d91e23ed#subdirectory=rtg-sims", 
  "ikz-trpl @ git+https://github.com/IKZ-Berlin/ikz-trpl.git@eff798a402344d65384c1b5666bf187747be01a6",
  "statsmodels",
  "plotly<6.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2550,7 +2550,7 @@ requires-dist = [
     { name = "nomad-measurements", marker = "extra == 'plugins'", git = "https://github.com/FAIRmat-NFDI/nomad-measurements.git?rev=v1.2.3" },
     { name = "plotly", marker = "extra == 'plugins'", specifier = "<6.0.0" },
     { name = "pyopenssl", marker = "extra == 'jupyter'" },
-    { name = "rtg-sims", marker = "extra == 'plugins'", git = "https://github.com/FAIRmat-NFDI/AreaA-data_modeling_and_schemas.git?subdirectory=rtg-sims&rev=c286f23d14dcb2e4dc32454f9ee1a2c467428c77" },
+    { name = "rtg-sims", marker = "extra == 'plugins'", git = "https://github.com/FAIRmat-NFDI/AreaA-data_modeling_and_schemas.git?subdirectory=rtg-sims&rev=d7db1bc694342aaf8d628da2febca237d91e23ed" },
     { name = "statsmodels", marker = "extra == 'plugins'" },
     { name = "voila", marker = "extra == 'jupyter'" },
 ]
@@ -2687,7 +2687,7 @@ infrastructure = [
 
 [[package]]
 name = "nomad-material-processing"
-version = "1.0.5.dev6+g8545ef374"
+version = "1.0.5.dev6+g8545ef3"
 source = { git = "https://github.com/FAIRmat-NFDI/nomad-material-processing.git?rev=8545ef374ac53169fe1e40be927a212a364ebda1#8545ef374ac53169fe1e40be927a212a364ebda1" }
 dependencies = [
     { name = "nomad-lab" },
@@ -4007,7 +4007,7 @@ wheels = [
 [[package]]
 name = "rtg-sims"
 version = "0.1.0"
-source = { git = "https://github.com/FAIRmat-NFDI/AreaA-data_modeling_and_schemas.git?subdirectory=rtg-sims&rev=c286f23d14dcb2e4dc32454f9ee1a2c467428c77#c286f23d14dcb2e4dc32454f9ee1a2c467428c77" }
+source = { git = "https://github.com/FAIRmat-NFDI/AreaA-data_modeling_and_schemas.git?subdirectory=rtg-sims&rev=d7db1bc694342aaf8d628da2febca237d91e23ed#d7db1bc694342aaf8d628da2febca237d91e23ed" }
 dependencies = [
     { name = "nomad-lab" },
     { name = "nomad-material-processing" },


### PR DESCRIPTION
Since setuptools-scm 9.0.1, the docker build of the oasis image raises an error if the `pyproject.toml` of a plugin does not have a `setuptools-scm` table. Adding this to the plugins and updating their commit hashes.